### PR TITLE
Doubled Enmity Decay rate to reduce the odds of players systaining en…

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -146,8 +146,7 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
             PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENSE_BOOST) ||
             PChar->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN))
         {
-            int tankStanceBonus = std::round(enmityBonus * 0.25f);
-            enmityBonus += tankStanceBonus;
+            enmityBonus += 25;
         }
     }
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -137,6 +137,17 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
         {
             enmityBonus -= PChar->PMeritPoints->GetMeritValue(MERIT_MUTED_SOUL, PChar);
         }
+        // Enmity Bonus for Tank Stance type effects  (Use of || Prevents multiple effects stacking with one another.)
+        if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENDER) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_FAN_DANCE) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MAJESTY) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENSE_BOOST) ||
+            PChar->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN))
+        {
+            enmityBonus += 0.25;
+        }
     }
 
     float bonus = (100.f + std::clamp(enmityBonus, -50, 100)) / 100.f;
@@ -484,7 +495,7 @@ void CEnmityContainer::DecayEnmity()
     for (auto& it : m_EnmityList)
     {
         EnmityObject_t& PEnmityObject = it.second;
-        constexpr int   decay_amount  = (int)(60 / server_tick_rate);
+        constexpr int   decay_amount  = (int)(120 / server_tick_rate);  //Enmity Decay rate Doubled
 
         PEnmityObject.VE -= PEnmityObject.VE > decay_amount ? decay_amount : PEnmityObject.VE;
     }

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -146,7 +146,8 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
             PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DEFENSE_BOOST) ||
             PChar->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN))
         {
-            enmityBonus += 0.25;
+            int tankStanceBonus = std::round(enmityBonus * 0.25f);
+            enmityBonus += tankStanceBonus;
         }
     }
 


### PR DESCRIPTION
…mity cap.

Provided a 25% boost to enmity when using a tank stance type abilities.

Specialized tank jobs are currently useless for multiple reasons with the primary reason being that everyone reaches enmity cap quickly and stays there, effectively removing the tank's ability to hold hate.  By increasing the decay rate of all enmity, it's harder to reach and stay at the enmity cap.  By making this increase equal for all jobs, there would be no perceived change to the existing hybrid job setup in any way.  By then increasing enmity generation for tank stances, this allows a specialized dedicated tank to more easily maintain hate.

While these changes make no difference to the hybrid job setups, it opens the door for custom fights that would require more specialized setups like a dedicated tank.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
