### PR TITLE
Successful Skillchains Reward an EXP Multiplier, which should bring t…

### DIFF
--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -107,6 +107,7 @@ enum MOBMODIFIER : int
     MOBMOD_NO_WIDESCAN            = 76, // Disables widescan for a specific mob
     MOBMOD_TRUST_DISTANCE         = 77, // TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
     MOBMOD_STANDBACK_RANGE        = 78, // Applies a specific standback range for the mob
+    MOBMOD_SC_EXP_BONUS           = 79, // Applies an exp bonus to mobs that suffer a skillchain
 
             // ASB Mod Start
     MOBMOD_DRAW_IN_INCLUDE_PARTY     = 100, // this will cause the mob's draw-in to also affect all party and alliance members

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4276,6 +4276,15 @@ namespace battleutils
         PDefender->takeDamage(damage, PAttacker, ATTACK_TYPE::SPECIAL,
                               appliedEle == ELEMENT_NONE ? DAMAGE_TYPE::NONE : static_cast<DAMAGE_TYPE>(elementOffset), true);
 
+        auto* PMob = dynamic_cast<CMobEntity*>(PDefender);
+        uint16 scmod = 0;
+        if(PMob->getMobMod(MOBMOD_SC_EXP_BONUS))
+        {
+            scmod = PMob->getMobMod(MOBMOD_SC_EXP_BONUS);
+        }
+        scmod += damage;
+        PMob->setMobMod(MOBMOD_SC_EXP_BONUS, scmod);
+
         battleutils::ClaimMob(PDefender, PAttacker);
         PDefender->updatemask |= UPDATE_STATUS;
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4649,6 +4649,15 @@ namespace charutils
                             }
                         }
                     }
+
+                    //Skillchain EXP Bonus Multiplier added after the exp chain cap
+                    if (PMob->getMobMod(MOBMOD_SC_EXP_BONUS))
+                    {
+                        const float monsterbonus = 1.f + PMob->getMobMod(MOBMOD_SC_EXP_BONUS) / 100.f;
+                        exp *= monsterbonus;
+                        exp = std::fmin(exp,20000); //Cap at 20000 exp per mob with a SC of 1000 damage or higher against a mob yielding 2k EXP or more 
+                    }
+
                     // pet or companion exp penalty needs to be added here
                     if (distance(PMember->loc.p, PMob->loc.p) > 100)
                     {


### PR DESCRIPTION
…raditional SC/MB parties back in line with other options

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

A New mob mod: SC EXP Bonus has been added.  When a successful skillchain is performed, this mob mod creates a multiplier for the exp rewarded from that mob equal to 1% of the damage dealt by the skillchain.  This stacks cumulatively  from all skillchains performed on a single mob.  The total exp that can be rewarded from a single mob regardless of how much skillchain damage is performed is capped at 20000.  The intention of this change is to bring traditional SC/MB parties targeting much stronger mobs back in line with the other options for EXP.

## Steps to test these changes

I thoroughly tested this in a local environment to ensure that the code operates correctly and does not cause any crashes or other issues.

<!-- Clear and detailed steps to test your changes here -->
