### PR TITLE
Desynth qo l proposal

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -238,9 +238,9 @@ namespace synthutils
         uint8 maxChanceHQ     = 50;
         uint8 randomRoll      = 0; // 1 to 100.
 
-        if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, lower base success rate.
+        if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, lower success rate.
         {
-            successRate = 45;
+            successRate = 75;  // Success rate still lower than regular crafts, however boosted to feel less bad.
             maxChanceHQ = 80;
         }
 
@@ -488,9 +488,9 @@ namespace synthutils
             // Chance penalties.
             uint8 penalty = 1;
 
-            if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, lower skill up rate
+            if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, higher skill up rate
             {
-                penalty += 1;
+                penalty -= 2;  // Desynthesis skill up rate higher than normal synthesis skill up rate as a QoL.
             }
 
             if (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL) // If synth breaks, lower skill up rate

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -490,10 +490,10 @@ namespace synthutils
 
             if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, higher skill up rate
             {
-                penalty -= 2;  // Desynthesis skill up rate higher than normal synthesis skill up rate as a QoL.
+                skillUpChance += 0.5;  // Desynthesis skill up rate higher than normal synthesis skill up rate as a QoL.
             }
 
-            if (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL) // If synth breaks, lower skill up rate
+            if (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL && PChar->CraftContainer->getCraftType() != CRAFT_DESYNTHESIS) // If synth breaks, lower skill up rate unless desynthesis
             {
                 penalty += 1;
             }
@@ -561,6 +561,11 @@ namespace synthutils
                         }
 
                         random = xirand::GetRandomNumber(1.);
+
+                        if(PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // Slight bonus to skill up amount when desynthing.
+                        {
+                            chance -= 0.1;
+                        }
 
                         if (chance < random)
                         {

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -240,7 +240,7 @@ namespace synthutils
 
         if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, lower success rate.
         {
-            successRate = 75;  // Success rate still lower than regular crafts, however boosted to feel less bad.
+            successRate = 75; // Success rate still lower than regular crafts, however boosted to feel less bad.
             maxChanceHQ = 80;
         }
 
@@ -490,7 +490,7 @@ namespace synthutils
 
             if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // If it's a desynth, higher skill up rate
             {
-                skillUpChance += 0.5;  // Desynthesis skill up rate higher than normal synthesis skill up rate as a QoL.
+                skillUpChance += 0.5; // Desynthesis skill up rate higher than normal synthesis skill up rate as a QoL.
             }
 
             if (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL && PChar->CraftContainer->getCraftType() != CRAFT_DESYNTHESIS) // If synth breaks, lower skill up rate unless desynthesis
@@ -562,7 +562,7 @@ namespace synthutils
 
                         random = xirand::GetRandomNumber(1.);
 
-                        if(PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // Slight bonus to skill up amount when desynthing.
+                        if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // Slight bonus to skill up amount when desynthing.
                         {
                             chance -= 0.1;
                         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Proposed subtle changes to desynthesis for QoL. The intended purpose of these changes are to make desynthesis feel better when being used to skill up a craft.

The changes include a substantial boost to the success rate, though it still remains lower than the normal synthesis success rate, and a bonus to skill up rates over normal synthesis. This also helps to alleviate the issue of a lack of economy with crafting by allowing much higher chance of skilling up with fewer mats and easier materials.
