### PR TITLE
Scythe Rework To be less FeelsBad

### DIFF
--- a/modules/cactuar/sql/cactuar_item_mods.sql
+++ b/modules/cactuar/sql/cactuar_item_mods.sql
@@ -834,6 +834,9 @@ REPLACE INTO `item_mods` (`itemid`, `modid`, `value`) VALUES
 (18330,559,3),   -- LIGHT_AFFINITY_PERP: 3
 (18330,560,3),   -- DARK_AFFINITY_PERP: 3
 
+--Apocalypse
+(18306,1000,1),  -- Physical Damage Limit: +1
+
 -- Swith Cape
 (11000,1,5),   -- DEF: 5
 (11000,2,-20), -- HP: -20

--- a/scripts/actions/weaponskills/aeolian_edge.lua
+++ b/scripts/actions/weaponskills/aeolian_edge.lua
@@ -16,6 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.ftpMod = { 2.75, 3.5, 4 }
     params.dex_wsc = 0.28 params.int_wsc = 0.28
+    params.hybridWS = true --Converted to Hybrid WS to allow for physical damage gear to enhance the WS.
     params.ele = xi.element.WIND
     params.skill = xi.skill.DAGGER
     params.includemab = true

--- a/scripts/actions/weaponskills/catastrophe.lua
+++ b/scripts/actions/weaponskills/catastrophe.lua
@@ -18,6 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 2.75, 2.75, 2.75 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.agi_wsc = 0.4 params.int_wsc = 0.4
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/cross_reaper.lua
+++ b/scripts/actions/weaponskills/cross_reaper.lua
@@ -13,6 +13,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftpMod = { 2.0, 2.25, 2.5 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3 params.mnd_wsc = 0.3
 

--- a/scripts/actions/weaponskills/dark_harvest.lua
+++ b/scripts/actions/weaponskills/dark_harvest.lua
@@ -16,6 +16,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.ftpMod = { 1.0, 2.0, 2.5 }
     params.str_wsc = 0.2 params.int_wsc = 0.2
+    params.hybridWS = true
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/entropy.lua
+++ b/scripts/actions/weaponskills/entropy.lua
@@ -18,6 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftpMod = { 0.75, 1.25, 2.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.int_wsc = player:getMerit(xi.merit.ENTROPY) * 0.17
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/guillotine.lua
+++ b/scripts/actions/weaponskills/guillotine.lua
@@ -13,6 +13,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftpMod = { 0.875, 0.875, 0.875 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.25
     params.mnd_wsc = 0.25

--- a/scripts/actions/weaponskills/herculean_slash.lua
+++ b/scripts/actions/weaponskills/herculean_slash.lua
@@ -17,6 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.ftpMod = { 3.5, 3.5, 3.5 }
     params.vit_wsc = 0.6
+    params.hybridWS = true --Convert to Hybrid WS
     params.ele = xi.element.ICE
     params.skill = xi.skill.GREAT_SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/infernal_scythe.lua
+++ b/scripts/actions/weaponskills/infernal_scythe.lua
@@ -18,6 +18,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftpMod = { 3.0, 3.0, 3.0 }
     -- params.ftpMod = { 3.5, 3.5, 3.5 }
     params.str_wsc = 0.3 params.int_wsc = 0.3
+    params.hybridWS = true
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/insurgency.lua
+++ b/scripts/actions/weaponskills/insurgency.lua
@@ -18,6 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftpMod = { 0.5, 0.75, 1.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.str_wsc = 0.2 params.int_wsc = 0.2
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/kings_justice.lua
+++ b/scripts/actions/weaponskills/kings_justice.lua
@@ -17,10 +17,11 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftpMod = { 1.0, 1.25, 1.5 }
+    params.atkVaries = { 1.5, 1.5, 1.5 } --REMA attack bonus to flatten the damage curve for REMA WSs
     params.str_wsc = 0.5
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftpMod = { 2.25, 4.00, 5.50 }
+        params.ftpMod = { 2.25, 3.75, 5.0 } --Reduced fTP to curb top end damage slightly
         -- params.ftpMod = { 1.0, 3.0, 5.0 }
         params.multiHitfTP = true
     end

--- a/scripts/actions/weaponskills/nightmare_scythe.lua
+++ b/scripts/actions/weaponskills/nightmare_scythe.lua
@@ -17,6 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.str_wsc = 0.3 params.mnd_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/quietus.lua
+++ b/scripts/actions/weaponskills/quietus.lua
@@ -17,6 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 3.0, 3.0, 3.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.str_wsc = 0.4 params.mnd_wsc = 0.4
     params.ignoredDefense = { 0.1, 0.3, 0.5 }
 

--- a/scripts/actions/weaponskills/shadow_of_death.lua
+++ b/scripts/actions/weaponskills/shadow_of_death.lua
@@ -16,6 +16,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.ftpMod = { 1.0, 2.5, 3.0 }
     params.str_wsc = 0.3 params.int_wsc = 0.3
+    params.hybridWS = true
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/slice.lua
+++ b/scripts/actions/weaponskills/slice.lua
@@ -13,12 +13,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 1.5, 1.75, 2.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 1.75, 2.5, 3.75 }
-        params.atkVaries = { 1.15, 1.15, 1.15 }
+        --params.atkVaries = { 1.15, 1.15, 1.15 }
         params.str_wsc = 1.0
     end
 

--- a/scripts/actions/weaponskills/spinning_scythe.lua
+++ b/scripts/actions/weaponskills/spinning_scythe.lua
@@ -17,6 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     params.str_wsc = 0.3
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/actions/weaponskills/vorpal_scythe.lua
+++ b/scripts/actions/weaponskills/vorpal_scythe.lua
@@ -13,6 +13,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftpMod = { 1.0, 1.0, 1.0 }
+    params.atkVaries  = { 1.25, 1.25, 1.25 }
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.35
     params.critVaries = { 0.3, 0.6, 0.9 }
@@ -20,7 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftpMod = { 2.0, 2.0, 2.0 }
         params.str_wsc = 1.0
-        params.atkVaries = { 1.0, 1.15, 1.25 }
+        --params.atkVaries = { 1.0, 1.15, 1.25 }
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -34,7 +34,7 @@ xi.aftermath.effects =
     [4]  = { mods = { xi.mod.CRITHITRATE, 10 }, duration = getTier1RelicDuration }, -- Ragnarok
     [5]  = { mods = { xi.mod.ATTP, 10 }, duration = getTier1RelicDuration }, -- Guttler
     [6]  = { mods = { xi.mod.DMG, -2000 }, duration = getTier1RelicDuration }, -- Bravura
-    [7]  = { mods = { xi.mod.HASTE_GEAR, 1000 }, duration = getTier1RelicDuration }, -- Apocalypse
+    [7]  = { mods = { xi.mod.HASTE_ABILITY, 1000 }, duration = getTier1RelicDuration }, -- Apocalypse
     -- [8]  = { mods = { xi.mod.SPIKES, xi.subEffect.SHOCK_SPIKES, xi.mod.SPIKES_DMG, 10 }, duration = getTier1RelicDuration }, -- Gungnir
     [8]  = { mods = { xi.mod.ENSPELL, xi.subEffect.LIGHTNING_DAMAGE, xi.mod.ENSPELL_DMG_BONUS, 20, xi.mod.SPIKES, xi.subEffect.SHOCK_SPIKES, xi.mod.SPIKES_DMG, 15, xi.mod.CRITHITRATE, 5 }, duration = getTier1RelicDuration, includePets = true }, -- Gungnir (Cactuar custom, increased crit rate 10%)
     [9]  = { mods = { xi.mod.SUBTLE_BLOW, 10 }, duration = getTier1RelicDuration }, -- Kikoku


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Subtle rework of Scythe and Apocalypse:

Apocalypse changes:

Added PDL + 1, raising pDIF from 2.4 cap to 3.4 cap.
Changed aftermath haste from Gear haste to Ability haste

Scythe Changes:

Changed all elemental WSs to Hybrid WSs.
Added a flat 25% attack bonus to all scythe weaponskills.


Rework Intentions:

Scythe is notorious for having the worst feeling weapon skills in the game.  This is primarily due to the WSs rarely being more than just an extra basic attack.  By adding an attack bonus to all weapon skills, this makes it easier to reach the pDIF cap when WSing, though not a free pDIF cap due to the bonus only being 25%.  This change will make all scythe WSs feel more impactful while still requiring intelligent gearing for WS.  Alongside this, all the elemental weaponskills are changed to hybrid WSs.  This allows DRK's primary gearing to be effective for these weapon skills bringing them in line with other scythe weapon skills allowing for skillchain variety and options.  

Alongside the weapon skill changes, adding a PDL increase to Apocalypse will allow for a properly geared and buffed Apoc DRK to be able to output DPS in-line with other relic weapons such as Bravura and Amanomurakumo.   This will ultimately still result in lower weaponskill numbers than Bravura can output, however the PDL increase's effects on regular basic attacks will bump the DPS up to be on par with other relic options.

By making the aftermath haste Ability haste, as it was originally when Apocalypse launched on retail, this allows for a DRK to gear differently based on their situation and adapt more easily.
