### PR TITLE
[sql] Vulpangue SDT Fix

### DIFF
--- a/sql/mob_resistances.sql
+++ b/sql/mob_resistances.sql
@@ -309,7 +309,7 @@ INSERT INTO `mob_resistances` VALUES (281,'Manticore-Kirin',0,0,0,0,0,0,0,0,0,0,
 INSERT INTO `mob_resistances` VALUES (282,'Tonberry-Grav_iton',0,0,0,0,0,0,0,0,0,0,0,0,0,-1,-3,-1,0,-2,1,4,0);
 INSERT INTO `mob_resistances` VALUES (284,'Vampyr',0,0,0,0,0,0,0,0,0,0,0,0,0,1,4,3,3,1,1,-1,11);
 INSERT INTO `mob_resistances` VALUES (285,'Gulool Ja Ja',0,0,0,0,0,0,0,0,0,0,0,0,0,4,2,9,9,4,4,4,4);
-INSERT INTO `mob_resistances` VALUES (286,'Puk - Vulpangue - ZMN Tier 1',20000,2500,0,0,0,0,0,0,0,0,0,0,0,-1,-2,11,-1,0,-1,-1,-1);
+INSERT INTO `mob_resistances` VALUES (286,'Puk - Vulpangue - ZMN Tier 1',0,2500,0,0,0,0,0,0,0,0,0,0,0,-1,-2,11,-1,0,-1,-1,-1);
 INSERT INTO `mob_resistances` VALUES (287,'Colibri - Chamrosh - ZMN Tier 1',0,2500,0,0,0,0,0,0,0,0,0,0,0,-1,-2,6,0,-1,-1,0,-2);
 INSERT INTO `mob_resistances` VALUES (288,'Qiqirn - Cheese Hoarder - ZNM Tier 1',0,0,0,0,0,0,0,0,0,0,0,0,0,-1,-1,-2,2,0,-1,-1,0);
 INSERT INTO `mob_resistances` VALUES (289,'Wamouracampa - BrassBorer - ZNM Tier 1',0,0,0,0,0,0,0,0,0,0,0,0,0,11,-2,2,-1,0,-2,0,-1);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes errant SLASH_SDT weakness from mob_resistances.sql for Vulpangue.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
